### PR TITLE
add docker toolbox example

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,12 @@
 
 - This guide walks through using an EC2 VM to get you started with Fli and utilizes Amazon Web Services CloudFormations which requires an AWS account. [Sign up for AWS for FREE here](https://aws.amazon.com/free/). 10-15 minutes.
 
+### Try `fli` by using the Docker Toolbox
+
+- This guide will use existing [Docker Toolbox](https://www.docker.com/products/docker-toolbox) installation to get you started using Fli in less then 10 minutes.
+
+[Try `fli` with Docker Toolbox ](fli-docker-toolbox/) 
+
 ### Try `fli` by using Ansible
 
 [Try `fli` in Ansible](fli-ansible/)

--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@
 
 ### Try `fli` by using the Docker Toolbox
 
-- This guide will use existing [Docker Toolbox](https://www.docker.com/products/docker-toolbox) installation to get you started using Fli in less then 10 minutes.
+[Try `fli` with Docker Toolbox ](fli-docker-toolbox/)
 
-[Try `fli` with Docker Toolbox ](fli-docker-toolbox/) 
+- This guide will use existing [Docker Toolbox](https://www.docker.com/products/docker-toolbox) installation to get you started using Fli in less then 10 minutes.
 
 ### Try `fli` by using Ansible
 

--- a/fli-docker-toolbox/README.md
+++ b/fli-docker-toolbox/README.md
@@ -18,7 +18,7 @@ sh startfli.sh
 ```
 docker-machine ssh flivm
 fli setup -z chq
-fli config -t <YOUR_TOKEN>
+fli config -t /root/<YOUR_TOKEN>
 fli init MyVolumeSet
 fli create MyVolumeSet MyVolume
 ```

--- a/fli-docker-toolbox/README.md
+++ b/fli-docker-toolbox/README.md
@@ -10,6 +10,8 @@ Install Docker Toolbox
 Run the install
 
 ```
+git clone https://github.com/ClusterHQ/examples
+cd examples/fli-docker-toolbox
 sh startfli.sh
 ```
 

--- a/fli-docker-toolbox/README.md
+++ b/fli-docker-toolbox/README.md
@@ -19,6 +19,7 @@ sh startfli.sh
 
 ```
 docker-machine ssh fli-vm
+source ~/.bashrc
 fli setup -z chq
 fli config -t /root/<YOUR_TOKEN>
 fli init MyVolumeSet

--- a/fli-docker-toolbox/README.md
+++ b/fli-docker-toolbox/README.md
@@ -25,6 +25,8 @@ sudo vi /root/token.txt
 fli config -t /root/token.txt
 fli init MyVolumeSet
 fli create MyVolumeSet MyVolume
+fli sync MyVolumeSet
+fli fetch <EXISTING-VOLUMESET>
 ```
 
 ## Cleanup

--- a/fli-docker-toolbox/README.md
+++ b/fli-docker-toolbox/README.md
@@ -1,0 +1,33 @@
+# Getting Started with Fli using Docker Toolbox.
+
+## Pre-requisites
+
+Install Docker Toolbox 
+ - https://www.docker.com/products/docker-toolbox
+
+## Start Fli
+
+Run the install
+
+```
+sh startfli.sh
+```
+
+## Use Fli
+
+```
+docker-machine ssh flivm
+fli setup -z chq
+fli config -t <YOUR_TOKEN>
+fli init MyVolumeSet
+fli create MyVolumeSet MyVolume
+```
+
+## Cleanup
+
+```
+sh cleanup.sh
+Docker Machine Ready...
+About to remove fli-vm
+Are you sure? (y/n): y
+```

--- a/fli-docker-toolbox/README.md
+++ b/fli-docker-toolbox/README.md
@@ -15,7 +15,7 @@ cd examples/fli-docker-toolbox
 sh startfli.sh
 ```
 
-## Use Fli
+## Configure Fli
 
 ```
 docker-machine ssh fli-vm
@@ -23,6 +23,11 @@ source ~/.bashrc
 fli setup -z chq
 sudo vi /root/token.txt
 fli config -t /root/token.txt
+```
+
+## Use Fli
+
+```
 fli init MyVolumeSet
 fli create MyVolumeSet MyVolume
 fli sync MyVolumeSet

--- a/fli-docker-toolbox/README.md
+++ b/fli-docker-toolbox/README.md
@@ -21,7 +21,8 @@ sh startfli.sh
 docker-machine ssh fli-vm
 source ~/.bashrc
 fli setup -z chq
-fli config -t /root/<YOUR_TOKEN>
+sudo vi /root/token.txt
+fli config -t /root/token.txt
 fli init MyVolumeSet
 fli create MyVolumeSet MyVolume
 ```

--- a/fli-docker-toolbox/README.md
+++ b/fli-docker-toolbox/README.md
@@ -16,7 +16,7 @@ sh startfli.sh
 ## Use Fli
 
 ```
-docker-machine ssh flivm
+docker-machine ssh fli-vm
 fli setup -z chq
 fli config -t /root/<YOUR_TOKEN>
 fli init MyVolumeSet

--- a/fli-docker-toolbox/cleanup.sh
+++ b/fli-docker-toolbox/cleanup.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+docker-machine --help > /dev/null
+
+if [ $? -eq 0 ]
+then
+  echo "Docker Machine Ready..."
+else
+  echo "Could not find Docker Machine" >&2
+  exit 1
+fi
+
+docker-machine rm fli-vm

--- a/fli-docker-toolbox/startfli.sh
+++ b/fli-docker-toolbox/startfli.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+docker-machine --help > /dev/null
+
+if [ $? -eq 0 ]
+then
+  echo "Docker Machine Ready..."
+else
+  echo "Could not find Docker Machine" >&2
+  exit 1
+fi
+
+docker-machine create -d virtualbox --virtualbox-boot2docker-url https://releases.rancher.com/os/latest/rancheros.iso fli-vm
+echo "y" | docker-machine ssh fli-vm "sudo ros console switch ubuntu" || true
+sleep 5 # vm restarts
+docker-machine ssh fli-vm "sudo ros service enable kernel-headers"
+docker-machine ssh fli-vm "sudo ros service up -d kernel-headers"
+docker-machine ssh fli-vm "sudo apt update -y -qq"
+docker-machine ssh fli-vm "sudo apt install -y -qq zfs"
+docker-machine ssh fli-vm "sudo ros config set rancher.modules [zfs]"
+docker-machine ssh fli-vm "sudo ros config set runcmd \"[[sh, -c, '[ -f /etc/zfs/zpool.cache ] && zpool import -c /etc/zfs/zpool.cache -a']]\""
+docker-machine ssh fli-vm "sudo modprobe zfs"
+docker-machine ssh fli-vm "sudo zpool list"
+docker-machine ssh fli-vm "sudo fallocate -l 5G /home/docker/zfs.disk"
+docker-machine ssh fli-vm "sudo zpool create -f chq /home/docker/zfs.disk"
+docker-machine ssh fli-vm "sudo echo \"alias fli='sudo docker run --rm --privileged -v /chq/:/chq/:shared -v /var/log/fli:/var/log/fli -v /root:/root -v /lib/modules:/lib/modules clusterhq/fli'\" >> /home/docker/.bashrc"
+docker-machine ssh fli-vm "docker run clusterhq/fli --help"
+
+echo ""
+echo "******************************************************************************************************************************"
+echo "Now run 'docker-machine ssh fli-vm' and start using Fli. Type 'source ~/.bashrc' then use Fli! Type 'fli --help' to verify"
+echo "******************************************************************************************************************************"
+echo ""


### PR DESCRIPTION
- Add an example thats the least amount of steps compared to Vagrant example.
- Requirements is just to install Docker Toolbox
- Piggybacks on RancherOS which enables ZFS.
  - http://docs.rancher.com/os/storage/using-zfs/
- Scripts to install and cleanup environment.
